### PR TITLE
fix: active route not highlighted on the top navbar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,10 +16,26 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     logo: '/icon.png',
     nav: [
-      { text: 'Install', link: '/install' },
-      { text: 'Gameplay', link: '/gameplay' },
-      { text: 'Playoffs', link: '/playoffs' },
-      { text: 'Contribute', link: '/contribute' }
+      { 
+        text: 'Install',
+        link: '/install',
+        activeMatch: '/install'
+      },
+      { 
+        text: 'Gameplay', 
+        link: '/gameplay',
+        activeMatch: '/gameplay'
+      },
+      { 
+        text: 'Playoffs',
+        link: '/playoffs',
+        activeMatch: '/playoffs'
+      },
+      { 
+        text: 'Contribute', 
+        link: '/contribute',
+        activeMatch: '/contribute'
+      }
     ],
 
     sidebar: {


### PR DESCRIPTION
Very minor change to the top navbar.

Before: 
![image](https://github.com/user-attachments/assets/0e037802-22fe-4f1d-8c33-6aba59d23403)
After:
![image](https://github.com/user-attachments/assets/59eb127d-9d12-45f2-89ce-f32ea14dddfb)

