### PR TITLE
Fixed Elo formula

### DIFF
--- a/docs/gameplay/elo_and_ranks.md
+++ b/docs/gameplay/elo_and_ranks.md
@@ -41,7 +41,7 @@ They are further separated into Divisions as follows:
 
 On a season end, all players with Elo above 1200 will have their Elo "reset" according to this formula:
 $$
-E' = \max(E - 1200, 0) \times 0.25 + E
+E' =  + \min(E, 1200 + (E - 1200) \times 0.25)
 $$
 In English, players below 1200 Elo are unaffected. Any extra Elo above 1200 that a player has is quartered. For example:
 ```


### PR DESCRIPTION
Fixed the Elo formula to work for ratings above 1200. Other formulas are possible; could be clearer if formulas didn't need to work for ratings below 1200.