### PR TITLE
Overworld structures in +x +z

### DIFF
--- a/docs/gameplay/seed.md
+++ b/docs/gameplay/seed.md
@@ -8,11 +8,11 @@ MCSR Ranked uses its own Seed Filter to select vanilla seeds which satisfy certa
 For more efficient filtering and usability, the overworld and nether are filtered via independent seeds. Therefore, strategies that can infer some RNG in the Nether, such as the Divine Travel strategy, will not work.
 
 ## Seed Type Distribution
-| Elo*       | Village | Shipwreck | Desert Temple | Ruined Portal | Buried Treasure |
+|    Elo*    | Village | Shipwreck | Desert Temple | Ruined Portal | Buried Treasure |
 | :--------: | :-----: | :-------: | :-----------: | :-----------: | :-------------: |
-| 0 ~ 599    | 55% | 30% | 15% |  0% |  0% |
-| 600 ~ 1199 | 30% | 30% | 20% | 20% |  0% |
-| 1200+      | 20% | 20% | 20% | 20% | 20% |
+|  0 ~ 599   |   55%   |    30%    |      15%      |      0%       |       0%        |
+| 600 ~ 1199 |   30%   |    30%    |      20%      |      20%      |       0%        |
+|   1200+    |   20%   |    20%    |      20%      |      20%      |       20%       |
 
 *: Based on the average Elo Rate of all players in the match.
 
@@ -22,7 +22,7 @@ In Private Room, each seeds have 20% distribution like 1200+ range.
 
 ### Village
 - Spawns within 7 chunks
-  - Always generated at positive coordinates for X and Y
+  - Always generated at positive coordinates for X and Z
 - Contains a guaranteed Blacksmith
 - 3 lava pools are guaranteed near the Village OR the Blacksmith contains 8+ Obsidian for an enter with blacksmith lava
 - Artificial lava pools look similar to vanilla and are the 3 guaranteed ones! There may be more vanilla lava pools but the artificial ones are guaranteed.
@@ -32,7 +32,7 @@ In Private Room, each seeds have 20% distribution like 1200+ range.
 
 ### Shipwreck
 - Spawns within 4 chunks
-  - Always generated at positive coordinates for X and Y
+  - Always generated at positive coordinates for X and Z
 - 2 Magma Ravines within 10 chunks of the Shipwreck
   - Filtered Magma Ravines are not generated in Frozen Ocean Biomes
 - At least 7 Iron (or 4 Iron + 3 Diamonds) and some food in food chest
@@ -42,7 +42,7 @@ In Private Room, each seeds have 20% distribution like 1200+ range.
 
 ### Desert Temple
 - Spawns within 5 chunks
-  - Always generated at positive coordinates for X and Y
+  - Always generated at positive coordinates for X and Z
 - 3 lava pools guaranteed near to the temple
 - Artificial lava pools look similar to vanilla and are the 3 guaranteed ones! There may be more vanilla lava pools but the artificial ones are guaranteed.
 - At least 7 Iron (or 4 Iron + 3 Diamonds)
@@ -51,7 +51,7 @@ In Private Room, each seeds have 20% distribution like 1200+ range.
 
 ### Ruined Portal
 - Spawns within 3 chunks
-  - Always generated at positive coordinates for X and Y
+  - Always generated at positive coordinates for X and Z
 - Enterable with Obsidian or Bucket (50/50)
 - There's a chance that there won’t be enough Iron for an Iron Pickaxe
 - Food in chest or animals within 5 chunks with a Flint and Steel / Fire Aspect Sword
@@ -60,7 +60,7 @@ In Private Room, each seeds have 20% distribution like 1200+ range.
 
 ### Buried Treasure
 - Spawns within 5 chunks
-  - Always generated at positive coordinates for X and Y
+  - Always generated at positive coordinates for X and Z
 - 2 Magma Ravines within 10 chunks of the Buried Treasure
   - Filtered Magma Ravines are not generated in Frozen Ocean Biomes
 - At least 7 Iron (or 4 Iron + 3 Diamonds)


### PR DESCRIPTION
Current official page says that all overworld structures will generate at +x +y coords, but I assume that this is meant to be +z instead of +y, since negative y coordinates would mean it is in the void.