### PR TITLE
Fix mistake in elo_and_ranks.md

### DIFF
--- a/docs/gameplay/elo_and_ranks.md
+++ b/docs/gameplay/elo_and_ranks.md
@@ -27,7 +27,7 @@ The playerbase is separated into 6 Ranks.
 | Elo         | Rank      | Notes
 | :---------: | :-------: | -----
 | 0 ~ 599     | Coal      | Lowest rank in the game.
-| 600 ~ 899   | Iron      | Unlocks Desert Temples as a seed type.
+| 600 ~ 899   | Iron      | Unlocks Ruined Portals as a seed type.
 | 900 ~ 1199  | Gold      | Most common rank.
 | 1200 ~ 1499 | Emerald   | Unlocks Buried Treasures as a seed type.
 | 1500 ~ 1999 | Diamond   | This roughly represents the top 5% of players.


### PR DESCRIPTION
Desert temples are always unlocked, iron unlocks ruined portals. See also: https://wiki.mcsrranked.com/gameplay/seed#seed-type-distribution
<img width="692" height="292" alt="image" src="https://github.com/user-attachments/assets/3450de8e-110c-4486-8d42-ba651b131b7d" />
