### PR TITLE
Switch osh's setup guide to draconix's guide

### DIFF
--- a/docs/install/install_prism.md
+++ b/docs/install/install_prism.md
@@ -1,7 +1,7 @@
 # Installation with Prism Launcher / MultiMC
 
 ## Launcher setup
-If you're new to speedrunning, we recommend following [osh's guide](https://youtu.be/OEpZlv6cQsI) for setting everything up.
+If you're new to speedrunning, we recommend following [draconix's guide](https://youtu.be/RSLv7FfQZKY) for setting everything up.
 
 ## Add Instance
 We recommend using the official modpack, which includes other allowed QoL and performance mods. Download it from [here](./download#modpack).


### PR DESCRIPTION
the main difference is explaining more things to set up in the guide, i.e. ninjabrainbot