### PR TITLE
fixed Piglin Barter probabilities

### DIFF
--- a/docs/gameplay/rng.md
+++ b/docs/gameplay/rng.md
@@ -8,9 +8,8 @@ The RNG Seed is same as Overworld seed by default. In private room, you can use 
 This document will describe what is standardized based on RNG Seed.
 
 ## Piglin Barters
-- Barter chances for Ender Pearls and Obsidian are increased
-- 6 Obsidian is guaranteed in the first 72 barters (8 Gold Blocks)
-- 3 Ender Pearl trades are guaranteed in the first 72 barters (8 Gold Blocks)
+- Barter chances for Obsidian is increased by approximately 3.5%
+- 6 Obsidian and 3 ender pearl trades are guaranteed for every 72 barters (8 Gold Blocks)
 - All players in the match have the same trades in the same order
 
 ## Entity Drop Loot
@@ -28,8 +27,8 @@ This document will describe what is standardized based on RNG Seed.
 - Eye of Ender throw break rates are standardized
   - Also, the 2nd eye throw will never break
 - Hunger effect rates from Rotten Flesh is standardized
-- Endermite spawn rates from Ender Pearl throw is standardized
-- Wool rates from sheep with shear uses are standardized
+- Endermite spawn rates from Ender Pearl throws is standardized
+- Wool rates from sheep while using shears are standardized
 
 ## Ender Dragon
 - Ender Dragon picks a standard node for zero cycle between 0-15 rather the regular 0-20 in vanilla, so it can still fly away, but the chance is lower and will be the same for all players in the match


### PR DESCRIPTION
The wiki claims that the barter rates for ender pearls are increased and barters are only guaranteed for the first 72 trades. My testing shows, that ender pearl rates are slightly decreased (~4.14%) from vanilla 1.16.1 rates (~4.73%), and RedLime confirmed that the guranteed barters occur for every set of 72 trades, not only the first 72 trades. My calculations are in this [spreadsheet](https://github.com/user-attachments/files/24172439/PiglinRNG.xlsx).



<img width="315" height="196" alt="grafik" src="https://github.com/user-attachments/assets/eef9bb50-4759-49c2-9cb5-0a501d0c8e4a" />



I gathered the data for the trades from this [website](https://char3210.github.io/RankedSeedInfo/), the amount of trades for a specific item is calculated with (amount)/(expected value) and the probability for the barter is calculated with (trades)/(total trades)*100.